### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,8 +18,8 @@ class perl::params {
   $cpan_mirror = 'http://www.perl.com/CPAN/'
 
   ### OS specific parameters
-  case $::operatingsystem {
-    /^(Debian|Ubuntu)$/ : {
+  case $::osfamily {
+    Debian : {
       $package          = 'perl'
       $doc_package      = 'perl-doc'
       $cpan_package     = 'perl'
@@ -28,7 +28,7 @@ class perl::params {
       $package_downcase = true
     }
 
-    /^(RedHat|CentOS|Amazon)$/ : {
+    RedHat : {
       $package          = 'perl'
       $doc_package      = ''
       $cpan_package     = 'perl-CPAN'


### PR DESCRIPTION
using osfamily matches many more variants of Linux and sets params more correctly.  E.X. This method would work on Scientific Linux (https://www.scientificlinux.org/) (RedHat OS family) and Bio-Linux (http://environmentalomics.org/bio-linux/) (Debian OS family)
